### PR TITLE
fix mysql sometimes not initializing properly

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,9 +3,7 @@
 
 cd /app/conreq || return
 
-python3 ./manage.py makemigrations
 python3 ./manage.py migrate
-python3 ./manage.py check
 
 # permissions
 chown -R abc:abc \


### PR DESCRIPTION
Seems like `makemigrations` cannot be run on a MySQL database that isn't already migrated. 

I've been committing my migrations files to the Conreq repo, so `makemigrations` isn't needed in the docker init.d

Also I removed `check` because isn't important to the end user. It's typically used during development time, prior to committing.