### PR TITLE
fix collectstatic on DATA_DIR locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,6 @@ RUN \
     /app/conreq --strip-components=1 && \
  echo "**** install pip packages ****" && \
  pip3 install --no-cache-dir -U -r /app/conreq/requirements.txt && \
- echo "**** generate static content ****" && \
- python3 /app/conreq/manage.py collectstatic && \
  echo "**** cleanup ****" && \
  apk del --purge \
     build-dependencies && \

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,7 +3,8 @@
 
 cd /app/conreq || return
 
-python3 ./manage.py migrate
+python3 ./manage.py migrate --noinput
+python3 ./manage.py collectstatic --link --noinput
 
 # permissions
 chown -R abc:abc \


### PR DESCRIPTION
Added `--noinput` parameters to any `manage.py` calls.

Also, to improve `collectstatic` speed I've implemented collecting via symlink rather than copy (`--link` parameter)