### PR TITLE
fix spelling, add background tasks, and fix running with SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Roxedus/docker-conreq](https://github.com/Roxedus/docker-conreq)
 
-Container for [Conrec](https://github.com/Archmonger/Conreq)
+Container for [Conreq](https://github.com/Archmonger/Conreq)
 
 ```yml
 ---

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -5,6 +5,7 @@ cd /app/conreq || return
 
 python3 ./manage.py migrate --noinput
 python3 ./manage.py collectstatic --link --noinput
+python3 ./manage.py compress
 python3 ./manage.py run_huey --quiet &
 
 # permissions

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -5,6 +5,7 @@ cd /app/conreq || return
 
 python3 ./manage.py migrate --noinput
 python3 ./manage.py collectstatic --link --noinput
+python3 ./manage.py run_huey --quiet &
 
 # permissions
 chown -R abc:abc \

--- a/root/etc/services.d/conreq/run
+++ b/root/etc/services.d/conreq/run
@@ -1,17 +1,24 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+# Standard execution parameters
+DAPHNE_PARAMS=("-b 0.0.0.0")
+
+# Check if SSL is enabled, and cert/keys exist
 if [[ "${SSL}" = true ]] && [ -f "$SSL_CERT" ] && [ -f "$SSL_KEY" ]; then
-    SSL_STRING=(-e "ssl:8000:privateKey=$SSL_KEY:certKey=$SSL_CERT")
-    export USE_SSL=True
+    # Instruct Daphne to use SSL via Twisted parameter passthrough
+    DAPHNE_PARAMS=("-e  ssl:8000:privateKey=$SSL_KEY:certKey=$SSL_CERT")
+
+# The user's key or cert file didn't exist
 elif [[ "${SSL}" = true ]]; then
-    [ ! -f "$SSL_CERT" ] && echo "Could not find the certificate $SSL_CERT, not starting with SSL"
-    [ ! -f "$SSL_KEY" ] && echo "Could not find the key $SSL_KEY, not starting with SSL"
+    # Notify the user that he messed up
+    [ ! -f "$SSL_CERT" ] && echo "Not starting with SSL. Could not find the certificate \"$SSL_CERT\""
+    [ ! -f "$SSL_KEY" ] && echo "Not starting with SSL. Could not find the key \"$SSL_KEY\""
 fi
 
 cd /app/conreq || exit 1
 
 exec \
-    s6-setuidgid abc daphne conreq.asgi:application \
-        -b 0.0.0.0 "${SSL_STRING[@]}" \
-        --access-log /config/logs/access.log
+    s6-setuidgid abc daphne $DAPHNE_PARAMS \
+    conreq.asgi:application \
+    --access-log /config/logs/access.log


### PR DESCRIPTION
Added `run_huey` to the init.d, since that's the platform I decided to use for running background tasks.

Also, fixed executing the daphne webserver with `SSL`.

You can't use `-b 0.0.0.0` when using `-e  ssl:8000:privateKey=$SSL_KEY:certKey=$SSL_CERT`.
The `-e` parameter causes Daphne to execute the webserver directly through the Twisted networking engine.
It seems like if you specify `-b` then it'll attempt to launch the webserver once through daphne's API, then a second time directly through Twisted resulting in _"port 8000 is in use"_ errors.

Tested and verified working.