### PR TITLE
run_conreq support and file cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/linuxserver/baseimage-alpine:3.13
 ARG CONREQ_VERSION
 
 # Temp Defaults
-ENV DATA_DIR=/config DEBUG=False WEBSERVER=Bjoern CRYPTOGRAPHY_DONT_BUILD_RUST=true
+ENV DATA_DIR=/config DEBUG=False CRYPTOGRAPHY_DONT_BUILD_RUST=true
 
 # hadolint ignore=DL3018,DL4006
 RUN \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Roxedus/docker-conreq](https://github.com/Roxedus/docker-conreq)
 
-## This is built againt the develop branch, you have been warned
+## This is built against the develop branch. You have been warned!
 
 ```yml
 ---
@@ -13,9 +13,6 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
-      - SSL=false #optional
-      - SSL_CERT=/config/crt.pem #Required when using SSL=true
-      - SSL_KEY=/config/key.pem #Required when using SSL=true
     volumes:
       - /path/to/config:/config
     ports:

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -5,4 +5,3 @@ cd /app/conreq || return
 
 # Permissions
 python3 manage.py preconfig_conreq $(id -u abc) $(id -g abc)
-chown -R abc:abc /app 

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -4,4 +4,4 @@
 cd /app/conreq || return
 
 # Permissions
-python3 manage.py preconfig_conreq $(id -u abc) $(id -g abc)
+python3 manage.py preconfig_conreq $PUID $PGID

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,12 +3,6 @@
 
 cd /app/conreq || return
 
-python3 ./manage.py migrate --noinput
-python3 ./manage.py collectstatic --link --noinput
-python3 ./manage.py compress
-s6-setuidgid abc python3 ./manage.py run_huey --quiet &
-
-# permissions
-chown -R abc:abc \
-    /app \
-    /config
+# Permissions
+python3 manage.py preconfig_conreq $(id -u abc) $(id -g abc)
+chown -R abc:abc /app 

--- a/root/etc/services.d/conreq/run
+++ b/root/etc/services.d/conreq/run
@@ -1,23 +1,9 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-if [[ "${SSL}" = true ]]; then
-    echo -e "Setting SSL with enviroment files is currently unsupported.\nPlease create, and do your configuration in /config/hypercorn.toml acording to the docs:\nhttps://pgjones.gitlab.io/hypercorn/how_to_guides/configuring.html#configuration-options"
-fi
-
-if [ -f "/config/hypercorn.toml" ]; then
-    HYPERCORN_PARAMS=(--config /config/hypercorn.toml)
-else
-    HYPERCORN_PARAMS=(--bind 0.0.0.0:8000 \
-    --access-logfile /config/logs/access.log \
-    --websocket-ping-interval 20 \
-    --workers 6 \
-    )
-fi
-
 cd /app/conreq || exit 1
 
 exec \
-    s6-setuidgid abc hypercorn \
-    "${HYPERCORN_PARAMS[@]}" \
-    conreq.asgi:application
+    s6-setuidgid abc python3 \
+     manage.py run_conreq \
+     --disable-preconfig


### PR DESCRIPTION
Adds support for the single start command of `run_conreq`, which allows for more granular control over the conreq startup process.

Additionally, `preconfig_conreq` is run to set up the file structure and permissions at first boot.